### PR TITLE
dbmaint - update column name validation and remove use of deprecated types

### DIFF
--- a/utils/dbmaint.q
+++ b/utils/dbmaint.q
@@ -74,7 +74,7 @@ add1table:{[dbdir;tablename;table]
  stdout"adding ",string tablename;
  @[tablename;`;:;.Q.en[dbdir]0#table];}
 
-stdout:{-1 raze[" "sv string`date`second$.z.Z]," ",x;}
+stdout:{-1 raze[" "sv string`date`second$.z.P]," ",x;}
 validcolname:{(not x in `i,.Q.res,key`.q)and x = .Q.id x}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/utils/dbmaint.q
+++ b/utils/dbmaint.q
@@ -75,7 +75,7 @@ add1table:{[dbdir;tablename;table]
  @[tablename;`;:;.Q.en[dbdir]0#table];}
 
 stdout:{-1 raze[" "sv string`date`second$.z.Z]," ",x;}
-validcolname:{$[all(sx:string x)in .Q.an;sx[0]in .Q.a,.Q.A;0b]}
+validcolname:{(not x in `i,.Q.res,key`.q)and x = .Q.id x}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 // * public


### PR DESCRIPTION
This brings `validcolname` broadly in-line with `.Q.id` and removes `datetime` usage in the logging function