### PR TITLE
fix move, changing time type & zone

### DIFF
--- a/tick/c.q
+++ b/tick/c.q
@@ -32,7 +32,7 @@ if[x~"vwap1";t:`trade;
 ind:{[t;i](key t)!flip(flip value t)@'\:i}
 if[x~"move";t:`trade;
  upd:{[t;x].[`.u.t;();,'';select time,size*price,size by sym from x];
-  move::((last each) each t)-ind[t:delete time from .u.t;exec time bin'-60000+"t"$.z.z from .u.t]}]
+  move::((last each) each t)-ind[t:delete time from .u.t;exec time bin'-60000000000+"n"$.z.Z from .u.t]}]
 
 / high low close volume
 if[x~"hlcv";t:`trade;hlcv:([sym:()]high:();low:();price:();size:());


### PR DESCRIPTION
Change to commonly used datatype in tick. Changed to use localtime as per tick, instead of UTC. Changes so that it runs 'out of the box' with tick.

For datatype change , before
```q
q)0N!"t"$.z.z;0N!-60000+"t"$.z.z;
16:31:16.789
16:30:16.789
```
after
```q
q)0N!"n"$.z.z;0N!-60000000000+"n"$.z.z;
0D16:31:16.774010000
0D16:30:16.774065000


```