### PR TITLE
fix using lvl2 with >1 sym

### DIFF
--- a/tick/c.q
+++ b/tick/c.q
@@ -41,7 +41,7 @@ if[x~"hlcv";t:`trade;hlcv:([sym:()]high:();low:();price:();size:());
 
 / lvl2 book for each sym
 if[x~"lvl2";t:`quote;s:`;
- lvl2:()!();upd:{[t;x]{lvl2[x`sym]^:`mm xkey enlist x _`sym}each x}]
+ lvl2:enlist[`]!enlist(::);upd:{[t;x]{lvl2[x`sym]^:`mm xkey enlist x _`sym}each x}]
   
 / nest all data (for arbitrary trend analysis)
 if[x~"nest";t:`trade;k:enlist`sym;


### PR DESCRIPTION
Running `q c.q lvl2 localhost:5000` , with feed publishing >1 sym leads to length error.
Recreation via standalone script
```q
lvl2:()!();
k)x:(+(,`mm)!,,`CC)!+`time`bid`ask`bsize`asize!(,0D20:12:10.536804000;,341.2832;,341.3243;,90;,858);
lvl2[`VOD.L]^:x;
k)x:(+(,`mm)!,,`DD)!+`time`bid`ask`bsize`asize!(,0D20:12:10.536804000;,341.2832;,341.3243;,90;,858);
lvl2[`VOD.L]^:x;
k)x:(+(,`mm)!,,`BB)!+`time`bid`ask`bsize`asize!(,0D20:12:10.536804000;,45.14739;,45.15186;,683;,585);
lvl2[`MSFT.O]^:x;
```

with change attached, no longer throws error & can perform objective again 
```q
q)lvl2[`VOD.L]
mm| time                 bid      ask      bsize asize
--| --------------------------------------------------
CC| 0D20:12:10.536804000 341.2832 341.3243 90    858  
DD| 0D20:12:10.536804000 341.2832 341.3243 90    858  
q)lvl2[`MSFT.O]
mm| time                 bid      ask      bsize asize
--| --------------------------------------------------
BB| 0D20:12:10.536804000 45.14739 45.15186 683   585 
```